### PR TITLE
Add setenv, getenv, and source-shell

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -122,6 +122,47 @@ closh: (sh ls) (sh echo hi)
 
 ## Reference
 
+### Environment variables
+
+There are some helper functions for doing common things with environment variables
+
+**setenv**: set environment variable
+```
+setenv "ONE" "1"
+=> ("1")
+(setenv "ONE" "1")
+=> ("1")
+(setenv "ONE" "1" "TWO" "2")
+=> ("1" "2")
+```
+
+**getenv**: get environment variable
+```
+getenv "ONE"
+=> "1"
+(getenv "ONE")
+=> "1"
+(getenv "ONE" "TWO")
+=> {"ONE" "1", "TWO" "2"}
+getenv
+=> ;; returns a map of all environment variables
+```
+
+**source-shell**: run bash scripts and import the resulting environment variables into the closh environment
+```
+(source-shell "export ONE=42")
+=> nil
+getenv "ONE"
+=> "42"
+```
+`source-shell` defaults to `bash` but you can use other shells:
+```
+(source-shell "zsh" "source complicated_script.zsh")
+=> nil
+getenv "SET_BY_COMPLICATED_SCRIPT"
+=> "..."
+```
+
 ### Custom prompt
 
 The prompt can be customized by defining `closh-prompt` function in `~/.closhrc` file.

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -163,6 +163,15 @@ getenv "SET_BY_COMPLICATED_SCRIPT"
 => "..."
 ```
 
+To set a temporary variable while running a command, do this:
+```
+env VAR=1 command
+```
+Which is equivalent to bash:
+```
+VAR=1 command
+```
+
 ### Custom prompt
 
 The prompt can be customized by defining `closh-prompt` function in `~/.closhrc` file.

--- a/src/closh/builtin.cljs
+++ b/src/closh/builtin.cljs
@@ -20,3 +20,29 @@
 (def quit
   "Alias for `exit`."
   exit)
+
+(defn jsx->clj
+  "Takes a js object and returns a cljs map. Use this when js->clj doesn't work a nonstandard object"
+  [x]
+  (into {} (for [k (js/Object.keys x)] [k (gobj/get x k)])))
+
+(defn getenv
+  "Gets environment variables. Given X args where X is:
+  0  - Returns a map of all environment variables and their values
+  1  - Returns the value of the specified environment variable as a string
+  >1 - Returns a map of the specified variables and their values"
+  [& args]
+  (let [ks (flatten args)]
+    (condp = (count ks)
+      0 (jsx->clj js/process.env)
+      1 (gobj/get js/process.env (first ks))
+      (into {} (map
+                #(vector % (gobj/get js/process.env %))
+                ks)))))
+
+(defn setenv
+  "Sets environment variables. Takes args as key value pairs and returns a list of values"
+  [& args]
+  (doall (map
+          (fn [[k v]] (aset js/process.env k v))
+          (partition 2 (flatten args)))))

--- a/src/closh/eval.cljs
+++ b/src/closh/eval.cljs
@@ -17,7 +17,8 @@
     '(do
        (require '[lumo.io :refer [slurp spit]]
                 '[closh.core :refer [shx expand expand-partial expand-command expand-redirect pipe pipe-multi pipe-map pipe-filter process-output wait-for-process wait-for-pipeline pipeline-condition process-value]]
-                '[closh.builtin :refer [cd exit quit]]
+                '[closh.builtin :refer [cd exit quit getenv setenv]]
+                '[closh.util :refer [source-shell]]
                 '[clojure.string :as st])
        (require-macros '[closh.core :refer [sh sh-str sh-code sh-ok sh-seq sh-lines sh-value]])
 

--- a/src/closh/main.cljs
+++ b/src/closh/main.cljs
@@ -7,6 +7,7 @@
             [lumo.repl]
             [closh.parser]
             [closh.builtin]
+            [closh.util]
             [closh.eval :refer [execute-text]]
             [closh.core :refer [handle-line]]
             [closh.history :refer [init-database add-history]])

--- a/src/closh/parser.cljc
+++ b/src/closh/parser.cljc
@@ -15,7 +15,7 @@
 
 (def ^:no-doc builtins
   "Set of symbols of builtin functions"
-  #{'cd 'exit 'quit})
+  #{'cd 'exit 'quit 'getenv 'setenv})
 
 (def ^:no-doc redirect-op
   "Set of symbols of redirection operators"

--- a/src/closh/util.cljs
+++ b/src/closh/util.cljs
@@ -1,0 +1,43 @@
+(ns closh.util
+  (:require [closh.builtin :refer [jsx->clj]]
+            [clojure.data :refer [diff]]
+            [goog.object :as gobj]))
+
+(def ^:no-doc fs (js/require "fs"))
+(def ^:no-doc child-process (js/require "child_process"))
+(def ^:no-doc os (js/require "os"))
+(def ^:no-doc path (js/require "path"))
+(def ^:no-doc tmp (js/require "tmp"))
+
+(def ignore-env-vars #{"_" "OLDPWD" "PWD" "SHELLOPTS" "SHLVL"})
+
+(defn spawn-shell
+  [shell exp]
+  (let [child (child-process.spawnSync shell #js["-c", exp])]
+    {:status (gobj/get child "status")
+     :stdout (str (gobj/get child "stdout"))
+     :stderr (str (gobj/get child "stderr"))}))
+
+(defn setenv-diff
+  [before after]
+  (let [var_diff (diff before after)
+        removed (remove #(ignore-env-vars (first %)) (first var_diff))
+        changed (remove #(ignore-env-vars (first %)) (second var_diff))]
+    (doseq [[k _] removed] (js-delete js/process.env k))
+    (doseq [[k v] changed] (gobj/set js/process.env k v))))
+
+(defn source-shell
+  "Spawns a shell interpreter and executes `exp`. If it executes successfully,
+  any exported variables are then saved into the closh environment"
+  ([exp] (source-shell "bash" exp))
+  ([shell exp]
+   (let [before (jsx->clj js/process.env)
+         temp-file (tmp.tmpNameSync)
+         result (spawn-shell shell (str exp "&& (node -p 'JSON.stringify(process.env)') >" temp-file))]
+     (if (= (:status result) 0)
+       (let [after (js->clj (js/JSON.parse (fs.readFileSync temp-file "utf8")))
+             stdout (:stdout result)]
+         (fs.unlinkSync temp-file)
+         (setenv-diff before after)
+         (when-not (= stdout "") stdout))
+       (println "Error while executing" shell "command:" exp "\n" (:stderr result))))))

--- a/test.cljs
+++ b/test.cljs
@@ -2,11 +2,12 @@
 
 (require '[goog.object :as gobj]
          '[clojure.test :refer [report run-tests]]
-         '[closh.core-test])
+         '[closh.core-test]
+         '[closh.util-test])
 
 (defmethod report [:cljs.test/default :end-run-tests] [m]
   (if (cljs.test/successful? m)
     (gobj/set js/process "exitCode" 0)
     (gobj/set js/process "exitCode" 1)))
 
-(time (run-tests 'closh.core-test))
+(time (run-tests 'closh.core-test 'closh.util-test))

--- a/test/closh/core_test.cljs
+++ b/test/closh/core_test.cljs
@@ -3,6 +3,8 @@
             [cljs.test :refer-macros [deftest testing is are run-tests]]
             [clojure.spec.alpha :as s]
             [clojure.string]
+            [goog.object :as gobj]
+            [closh.builtin :refer [jsx->clj getenv setenv]]
             [closh.parser :refer [parse-batch]]
             [closh.eval :refer [execute-text]]
             [closh.core :refer [handle-line shx expand expand-partial process-output line-seq pipe pipe-multi pipe-map pipe-filter pipeline-value wait-for-pipeline pipeline-condition]
@@ -463,3 +465,21 @@
             :stdout "YES\n"}
            (-> (closh-spawn "_asdfghj_ || echo YES")
                (select-keys [:stdout :stderr]))))))
+
+(deftest test-builtin-getenv-setenv
+
+  (is (= (jsx->clj js/process.env) (getenv)))
+
+  (is (= '("forty two") (setenv "A" "forty two")))
+  (is (= (gobj/get js/process.env "A") (getenv "A")))
+
+  (setenv "A" "forty
+two")
+  (is (= "forty\ntwo" (getenv "A")))
+
+  (is (= '("1" "2") (setenv "ONE" "1" "TWO" "2")))
+  (is (= {"ONE" "1", "TWO" "2"}
+         (getenv "ONE" "TWO")))
+
+  (is (= (pr-str (setenv "ONE" "6")) (:stdout (closh "setenv \"ONE\" \"6\""))))
+  (is (= (getenv "ONE") (:stdout (closh "getenv \"ONE\"")))))

--- a/test/closh/util_test.cljs
+++ b/test/closh/util_test.cljs
@@ -1,0 +1,22 @@
+(ns closh.util-test
+  (:require [cljs.test :refer-macros [deftest testing is are run-tests]]
+            [goog.object :as gobj]
+            [closh.util :refer [source-shell]]))
+
+(deftest test-source-shell
+
+  (is (= nil (source-shell "export A=42")))
+  (is (= "42" (gobj/get js/process.env "A")))
+
+  (source-shell "A=84")
+  (is (= "84" (gobj/get js/process.env "A")))
+
+  (source-shell "unset A")
+  (is (= nil (gobj/get js/process.env "A")))
+
+  (source-shell "export A='forty two'")
+  (is (= "forty two" (gobj/get js/process.env "A")))
+
+  (source-shell "export A='forty
+two'")
+  (is (= "forty\ntwo" (gobj/get js/process.env "A"))))


### PR DESCRIPTION
Added some commands

* setenv: set environment variable (builtin)
* getenv: get environment variable (builtin)
* source-shell: run bash scripts and import the resulting environment variables into the closh environment (regular function)

Added tests and examples in `guide.md`