### PR TITLE
Use expand-tilde inside expand-filename

### DIFF
--- a/src/closh/core.cljs
+++ b/src/closh/core.cljs
@@ -29,7 +29,7 @@
 (defn expand-filename
   "Expands filename based on globbing patterns"
   [s]
-  (seq (glob s #js{:nonull true})))
+  (seq (glob (expand-tilde s) #js{:nonull true})))
 
 (defn expand-redirect
   "Expand redirect targets. It does tilde and variable expansion."


### PR DESCRIPTION
This PR make it possible to use `expand-filename` that can expand `~` (tilde).

So that we can use something like `(expand-tiles "~/Dropbox/config/*.edn")` in code.