### PR TITLE
closh.sh should work under Linux and macOS

### DIFF
--- a/bin/closh.sh
+++ b/bin/closh.sh
@@ -1,15 +1,59 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
-# resolve link from node wrapper to the real lumo binary
-LUMO_BIN=$(which lumo)
-if test -L "$LUMO_BIN"
-then
-  LUMO_BIN=$(dirname $(readlink -f "$LUMO_BIN"))/lumo
-fi
+# Resolve a file to its canonical path, following symlinks
+# https://stackoverflow.com/a/29835459
+rreadlink() {
 
-export CLOSH_SOURCES_PATH=$(dirname $(dirname $(realpath "$0")))
+  target=$1 fname= targetDir= CDPATH=
+
+  # Try to make the execution environment as predictable as possible:
+  # All commands below are invoked via `command`, so we must make sure that `command`
+  # itself is not redefined as an alias or shell function.
+  # (Note that command is too inconsistent across shells, so we don't use it.)
+  # `command` is a *builtin* in bash, dash, ksh, zsh, and some platforms do not even have
+  # an external utility version of it (e.g, Ubuntu).
+  # `command` bypasses aliases and shell functions and also finds builtins 
+  # in bash, dash, and ksh. In zsh, option POSIX_BUILTINS must be turned on for that
+  # to happen.
+  { \unalias command; \unset -f command; } >/dev/null 2>&1
+  [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on # make zsh find *builtins* with `command` too.
+
+  while :; do # Resolve potential symlinks until the ultimate target is found.
+    [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
+    command cd "$(command dirname -- "$target")" # Change to target dir; necessary for correct resolution of target path.
+    fname=$(command basename -- "$target") # Extract filename.
+    [ "$fname" = '/' ] && fname='' # !! curiously, `basename /` returns '/'
+    if [ -L "$fname" ]; then
+      # Extract [next] target path, which may be defined
+      # *relative* to the symlink's own directory.
+      # Note: We parse `ls -l` output to find the symlink target
+      #       which is the only POSIX-compliant, albeit somewhat fragile, way.
+      target=$(command ls -l "$fname")
+      target=${target#* -> }
+      continue # Resolve [next] symlink target.
+    fi
+    break # Ultimate target reached.
+  done
+  targetDir=$(command pwd -P) # Get canonical dir. path
+  # Output the ultimate target's canonical path.
+  # Note that we manually resolve paths ending in /. and /.. to make sure we have a normalized path.
+  if [ "$fname" = '.' ]; then
+    command printf '%s\n' "${targetDir%/}"
+  elif  [ "$fname" = '..' ]; then
+    # Caveat: something like /var/.. will resolve to /private (assuming /var@ -> /private/var), i.e. the '..' is applied
+    # AFTER canonicalization.
+    command printf '%s\n' "$(command dirname -- "${targetDir}")"
+  else
+    command printf '%s\n' "${targetDir%/}/$fname"
+  fi
+}
+
+
+CLOSH_SOURCES_PATH="$(dirname "$(dirname "$(rreadlink "$0")")")"
+export CLOSH_SOURCES_PATH
 
 # NODE_PATH seems to be missing when running as global binary
-export NODE_PATH="$CLOSH_SOURCES_PATH/node_modules:$CLOSH_SOURCES_PATH/..:$NODE_PATH"
+NODE_PATH="$CLOSH_SOURCES_PATH/node_modules$([ -n "$NODE_PATH" ] && printf ":%s" "$NODE_PATH")"
+export NODE_PATH
 
-exec "$LUMO_BIN" --classpath "$CLOSH_SOURCES_PATH/src" --cache "$HOME/.lumo_cache" -m closh.main
+exec lumo --classpath "$CLOSH_SOURCES_PATH/src" --cache "$HOME/.lumo_cache" -m closh.main

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "tmp": "0.0.33"
   },
   "scripts": {
-    "start": "node ./bin/closh.js",
+    "start": "./bin/closh.sh",
     "dev": "nodemon --config .nodemon.json",
     "docker-build": "docker build . -t closh",
     "docker-start": "npm run docker-build && docker run --rm -it closh",


### PR DESCRIPTION
Addresses #52 

I removed two things because I couldn't figure out what they were for:
1. Resolving the path of `lumo`
2. Adding `$CLOSH_SOURCES_PATH/..` to `$NODE_PATH`

If those are useful, let me know and I can add them back