### PR TITLE
Boilerplate for single binary compilation of closh

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "glob": "7.1.2",
     "lumo-cljs": "1.9.0-alpha",
     "sqlite3": "3.1.13",
+    "string_decoder": "^1.1.1",
     "tmp": "0.0.33"
   },
   "devDependencies": {

--- a/scripts/patch_deasync.js
+++ b/scripts/patch_deasync.js
@@ -1,0 +1,123 @@
+/*!
+ * deasync
+ * https://github.com/abbr/deasync
+ *
+ * Copyright 2014-2015 Abbr
+ * Released under the MIT license
+ */
+
+
+
+
+(function () {
+    
+    var fs = require('fs'),
+        os = require('os'),
+        path = require('path'),
+        zlib = require('zlib'),
+        binding;
+
+    function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
+        const sep = path.sep;
+        const initDir = path.isAbsolute(targetDir) ? sep : '';
+        const baseDir = isRelativeToScript ? __dirname : '.';
+
+        return targetDir.split(sep).reduce((parentDir, childDir) => {
+            const curDir = path.resolve(baseDir, parentDir, childDir);
+            try {
+                fs.mkdirSync(curDir);
+            } catch (err) {
+                if (err.code === 'EEXIST') { // curDir already exists!
+                    return curDir;
+                }
+
+                // To avoid `EISDIR` error on Mac and `EACCES`-->`ENOENT` and `EPERM` on Windows.
+                if (err.code === 'ENOENT') { // Throw the original parentDir error on curDir `ENOENT` failure.
+                    throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
+                }
+
+                const caughtErr = ['EACCES', 'EPERM', 'EISDIR'].indexOf(err.code) > -1;
+                if (!caughtErr || caughtErr && targetDir === curDir) {
+                    throw err; // Throw if it's just the last created dir.
+                }
+            }
+
+            return curDir;
+        }, initDir);
+    }
+    
+    // Seed random numbers [gh-82] if on Windows. See https://github.com/laverdet/node-fibers/issues/82
+    if(process.platform === 'win32') Math.random();
+    
+    
+    // Look for binary for this platform
+    var nodeV = 'node-9';
+    var modPath = path.join(os.homedir(), '.closh', 'deasync', process.platform + '-' + process.arch + '-' + nodeV, 'deasync.node');
+
+    try{
+	fs.statSync(modPath);
+    }
+    catch(ex){
+        let bundledPath = process.platform + '-' + process.arch + '-' + nodeV + '/' + 'deasync.node';
+        let bundledPathRegex = new RegExp(bundledPath + '$', 'i');
+        let embedded_files = lumo.internal.embedded.keys();
+        let embedded_binary_path = embedded_files.filter(function(item){
+            return bundledPathRegex.test(item);
+        });
+        let buffered_binary = lumo.internal.embedded.get(embedded_binary_path[0]);
+        let deflated_binary = zlib.inflateSync(buffered_binary);
+
+        // Write dir in .closh if not existing
+        mkDirByPathSync(path.dirname(modPath));
+        // Write the binary buffer to disk
+        fs.writeFileSync(modPath, deflated_binary, "binary", function(err) {
+            if(err) {
+                console.error(err);
+                process.exit(-1);
+            }
+        });
+    }
+
+    binding = require(modPath);
+
+    function deasync(fn) {
+	return function() {
+	    var done = false;
+	    var args = Array.prototype.slice.apply(arguments).concat(cb);
+	    var err;
+	    var res;
+
+	    fn.apply(this, args);
+	    module.exports.loopWhile(function(){return !done;});
+	    if (err)
+		throw err;
+
+	    return res;
+
+	    function cb(e, r) {
+		err = e;
+		res = r;
+		done = true;		
+	    }
+	}
+    }
+    
+    module.exports = deasync;
+    
+    module.exports.sleep = deasync(function(timeout, done) {
+	setTimeout(done, timeout);
+    });
+    
+    module.exports.runLoopOnce = function(){
+	process._tickCallback();
+	binding.run();
+    };
+    
+    module.exports.loopWhile = function(pred){
+	while(pred()){
+	    process._tickCallback();
+	    if(pred()) binding.run();
+	}
+    };
+
+}());

--- a/scripts/patch_sqlite3.js
+++ b/scripts/patch_sqlite3.js
@@ -1,0 +1,248 @@
+// var binary = require('node-pre-gyp');
+var path = require('path');
+var fs = require('fs');
+var os = require('os');
+var zlib = require('zlib');
+
+const sqlite3v = "v3.1.13";
+
+function mkDirByPathSync(targetDir, { isRelativeToScript = false } = {}) {
+    const sep = path.sep;
+    const initDir = path.isAbsolute(targetDir) ? sep : '';
+    const baseDir = isRelativeToScript ? __dirname : '.';
+
+    return targetDir.split(sep).reduce((parentDir, childDir) => {
+        const curDir = path.resolve(baseDir, parentDir, childDir);
+        try {
+            fs.mkdirSync(curDir);
+        } catch (err) {
+            if (err.code === 'EEXIST') { // curDir already exists!
+                return curDir;
+            }
+
+            // To avoid `EISDIR` error on Mac and `EACCES`-->`ENOENT` and `EPERM` on Windows.
+            if (err.code === 'ENOENT') { // Throw the original parentDir error on curDir `ENOENT` failure.
+                throw new Error(`EACCES: permission denied, mkdir '${parentDir}'`);
+            }
+
+            const caughtErr = ['EACCES', 'EPERM', 'EISDIR'].indexOf(err.code) > -1;
+            if (!caughtErr || caughtErr && targetDir === curDir) {
+                throw err; // Throw if it's just the last created dir.
+            }
+        }
+
+        return curDir;
+    }, initDir);
+}
+
+const binaryDir = path.join(os.homedir(), '.closh', `sqlite3-${sqlite3v}`);
+const binaryLoc = path.join(binaryDir, 'node_sqlite3.node');
+
+var binding;
+
+// make sure the file exists and has been downloaded, `else` case should really never happen
+if (fs.existsSync(binaryLoc)) {
+    binding = require(binaryLoc);
+} else {
+    let embedded_files = lumo.internal.embedded.keys();
+    let embedded_binary_path = embedded_files.filter(function(item){
+        return /node_sqlite3.node$/g.test(item);
+    });
+    let buffered_binary = lumo.internal.embedded.get(embedded_binary_path[0]);
+    let deflated_binary = zlib.inflateSync(buffered_binary);
+    
+    // Write dir in .closh if not existing
+    mkDirByPathSync(binaryDir);
+    fs.writeFileSync(binaryLoc, deflated_binary, "binary", function(err) {
+        if(err) {
+            console.error(err);
+            process.exit(-1);
+        }
+    });
+    binding = require(binaryLoc);
+}
+
+var sqlite3 = module.exports = exports = binding;
+var EventEmitter = require('events').EventEmitter;
+
+function normalizeMethod (fn) {
+    return function (sql) {
+        var errBack;
+        var args = Array.prototype.slice.call(arguments, 1);
+        if (typeof args[args.length - 1] === 'function') {
+            var callback = args[args.length - 1];
+            errBack = function(err) {
+                if (err) {
+                    callback(err);
+                }
+            };
+        }
+        var statement = new Statement(this, sql, errBack);
+        return fn.call(this, statement, args);
+    };
+}
+
+function inherits(target, source) {
+    for (var k in source.prototype)
+        target.prototype[k] = source.prototype[k];
+}
+
+sqlite3.cached = {
+    Database: function(file, a, b) {
+        if (file === '' || file === ':memory:') {
+            // Don't cache special databases.
+            return new Database(file, a, b);
+        }
+
+        var db;
+        file = path.resolve(file);
+        function cb() { callback.call(db, null); }
+
+        if (!sqlite3.cached.objects[file]) {
+            db = sqlite3.cached.objects[file] = new Database(file, a, b);
+        }
+        else {
+            // Make sure the callback is called.
+            db = sqlite3.cached.objects[file];
+            var callback = (typeof a === 'number') ? b : a;
+            if (typeof callback === 'function') {
+                if (db.open) process.nextTick(cb);
+                else db.once('open', cb);
+            }
+        }
+
+        return db;
+    },
+    objects: {}
+};
+
+
+var Database = sqlite3.Database;
+var Statement = sqlite3.Statement;
+
+inherits(Database, EventEmitter);
+inherits(Statement, EventEmitter);
+
+// Database#prepare(sql, [bind1, bind2, ...], [callback])
+Database.prototype.prepare = normalizeMethod(function(statement, params) {
+    return params.length
+        ? statement.bind.apply(statement, params)
+        : statement;
+});
+
+// Database#run(sql, [bind1, bind2, ...], [callback])
+Database.prototype.run = normalizeMethod(function(statement, params) {
+    statement.run.apply(statement, params).finalize();
+    return this;
+});
+
+// Database#get(sql, [bind1, bind2, ...], [callback])
+Database.prototype.get = normalizeMethod(function(statement, params) {
+    statement.get.apply(statement, params).finalize();
+    return this;
+});
+
+// Database#all(sql, [bind1, bind2, ...], [callback])
+Database.prototype.all = normalizeMethod(function(statement, params) {
+    statement.all.apply(statement, params).finalize();
+    return this;
+});
+
+// Database#each(sql, [bind1, bind2, ...], [callback], [complete])
+Database.prototype.each = normalizeMethod(function(statement, params) {
+    statement.each.apply(statement, params).finalize();
+    return this;
+});
+
+Database.prototype.map = normalizeMethod(function(statement, params) {
+    statement.map.apply(statement, params).finalize();
+    return this;
+});
+
+Statement.prototype.map = function() {
+    var params = Array.prototype.slice.call(arguments);
+    var callback = params.pop();
+    params.push(function(err, rows) {
+        if (err) return callback(err);
+        var result = {};
+        if (rows.length) {
+            var keys = Object.keys(rows[0]), key = keys[0];
+            if (keys.length > 2) {
+                // Value is an object
+                for (var i = 0; i < rows.length; i++) {
+                    result[rows[i][key]] = rows[i];
+                }
+            } else {
+                var value = keys[1];
+                // Value is a plain value
+                for (i = 0; i < rows.length; i++) {
+                    result[rows[i][key]] = rows[i][value];
+                }
+            }
+        }
+        callback(err, result);
+    });
+    return this.all.apply(this, params);
+};
+
+var isVerbose = false;
+
+var supportedEvents = [ 'trace', 'profile', 'insert', 'update', 'delete' ];
+
+Database.prototype.addListener = Database.prototype.on = function(type) {
+    var val = EventEmitter.prototype.addListener.apply(this, arguments);
+    if (supportedEvents.indexOf(type) >= 0) {
+        this.configure(type, true);
+    }
+    return val;
+};
+
+Database.prototype.removeListener = function(type) {
+    var val = EventEmitter.prototype.removeListener.apply(this, arguments);
+    if (supportedEvents.indexOf(type) >= 0 && !this._events[type]) {
+        this.configure(type, false);
+    }
+    return val;
+};
+
+Database.prototype.removeAllListeners = function(type) {
+    var val = EventEmitter.prototype.removeAllListeners.apply(this, arguments);
+    if (supportedEvents.indexOf(type) >= 0) {
+        this.configure(type, false);
+    }
+    return val;
+};
+
+// Save the stack trace over EIO callbacks.
+sqlite3.verbose = function() {
+    if (!isVerbose) {
+        var trace = require('./trace');
+        [
+            'prepare',
+            'get',
+            'run',
+            'all',
+            'each',
+            'map',
+            'close',
+            'exec'
+        ].forEach(function (name) {
+            trace.extendTrace(Database.prototype, name);
+        });
+        [
+            'bind',
+            'get',
+            'run',
+            'all',
+            'each',
+            'map',
+            'reset',
+            'finalize',
+        ].forEach(function (name) {
+            trace.extendTrace(Statement.prototype, name);
+        });
+        isVerbose = true;
+    }
+
+    return this;
+};


### PR DESCRIPTION
As discussed here https://github.com/dundalek/closh/issues/42 compiling closh into a single executable binary is painful. But with this PR plus pkg-lumo 1.0.1, this is possible by running the following command from within the closh directory (in my commit):

```
$ pkg-lumo --classpath src --replaceFiles '{"./node_modules/deasync/index.js": "./scripts/patch_deasync.js", "./node_modules/sqlite3/lib/sqlite3.js": "./scripts/patch_sqlite3.js"}' --main closh.main
```

pkg-lumo: https://github.com/hlolli/pkg-lumo

This changes the way sqlite is required. For non-binary closh this shouldn't be a problem, as require.resolve for "sqlite3" will indicate that node found the module inside node_modules and won't make any attempt to download the .node file. Bear in mind that this .node binary fetching is done my node-pre-gyp every time you install sqlite3 via npm on any computer.

Pathing deasync was quite easier, as the package itself is shipped with .node binaries for all distros, so no need to fetch them over the wire dynamically.