### PR TITLE
Remove spaces between the heredoc string

### DIFF
--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -43,7 +43,7 @@ The development of closh is currently focused on the interactive mode and explor
 ```
 #!/bin/sh
 
-clojure -Sdeps '{:deps {closh {:git/url "https://github.com/dundalek/closh.git" :sha "f6416f81bf132a037fcf437ed07dc09adb4c14b7"}}}' - <<END
+clojure -Sdeps '{:deps {closh {:git/url "https://github.com/dundalek/closh.git" :sha "c876716ab2e27514c0b794ef45aeabec7a926493"}}}' -<<END
 
 (require '[closh.zero.macros :refer :all]
          '[closh.zero.core :refer :all]


### PR DESCRIPTION
Hii @dundalek,
Thanks for a great library. This is a simple PR to fix the information in the cookbook to make it work properly. Also I update the script to use the most recent version of the sha.

Thanks
Burin