### PR TITLE
Fix: exit (/quit) should allow zero arguments call

### DIFF
--- a/src/closh/zero/builtin.cljc
+++ b/src/closh/zero/builtin.cljc
@@ -4,8 +4,10 @@
 
 (defn exit
   "Exits the process using optional first argument as exit code."
-  [code & _]
-  (process/exit code))
+  ([]
+   (exit 0))
+  ([code & _]
+   (process/exit code)))
 
 (def quit
   "Alias for `exit`."


### PR DESCRIPTION
Like the doc string and to prevent unexpected behaviour
```
ArityException Wrong number of args (0) passed to: builtin/exit  clojure.lang.AFn.throwArity (AFn.java:429)
```

I also find this inconsistent with bash:
```
$ exit 2
ClassCastException java.lang.String cannot be cast to java.lang.Number  closh.zero.platform.process/exit (process.clj:18)
```

I would say if it's an alias to a bash function it's should behave like a bash function? WDYT?