### PR TITLE
Experiment with nrepl

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,8 @@
   compliment {:mvn/version "0.3.6"}
   cljfmt {:mvn/version "0.5.7" :exclusions [org.clojure/tools.reader]}
 
+  org.clojure/tools.nrepl {:mvn/version "0.2.13"}
+
   ; rebel-readline -> cljfmt -> rewrite-cljs,rewrite-clj
   rewrite-cljs  {:mvn/version "0.4.3"  :exclusions [org.clojure/tools.reader]}
   rewrite-clj {:mvn/version  "0.5.2" :exclusions [org.clojure/tools.reader]}}


### PR DESCRIPTION
Although this is easy, not sure what the best way to add it is, as you will get port conflicts and the boot time is at least doubled. But here we go:

With dependency added, change `~/.closhrc` to:

```
(defn closh-prompt []
  "$ (custom):")

(def nrepl-port 7888)
(println "Starting nrepl at" nrepl-port)
(use '[clojure.tools.nrepl.server :only (start-server stop-server)])
(defonce server (start-server :port nrepl-port))
```
Start shell
```
➜  ~ java -jar project.jar
Starting nrepl at 7888
$ (custom):
```
In another shell
```
➜  ~ lein repl :connect 7888
Connecting to nREPL at 127.0.0.1:7888
REPL-y 0.3.7, nREPL 0.2.13
Clojure 1.9.0
Java HotSpot(TM) 64-Bit Server VM 1.8.0_141-b15
    Docs: (doc function-name-here)
          (find-doc "part-of-name-here")
  Source: (source function-name-here)
 Javadoc: (javadoc java-object-or-class-here)
    Exit: Control+D or (exit) or (quit)
 Results: Stored in vars *1, *2, *3, an exception in *e

user=> (in-ns 'cDisplay all 120 possibilities? (y or n)
user=> (in-ns 'closh.zero.
closh.zero.builtin              closh.zero.compiler             closh.zero.core                 closh.zero.env                  closh.zero.frontend.main        closh.zero.frontend.rebel
closh.zero.macros               closh.zero.parser               closh.zero.pipeline             closh.zero.platform.io          closh.zero.platform.process     closh.zero.reader
closh.zero.service.completion   closh.zero.util
user=> (in-ns 'closh.zero.
```

