### PR TITLE
Build with Xcode 10.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
 
   test-macos-cljs:
     macos:
-      xcode: "9.1.0"
+      xcode: "10.2.1"
 
     working_directory: /Users/distiller/project
 
@@ -101,7 +101,7 @@ jobs:
 
   test-macos-clj:
     macos:
-      xcode: "9.1.0"
+      xcode: "10.2.1"
 
     working_directory: /Users/distiller/project
 


### PR DESCRIPTION
At CircleCI we are going to be sun-setting the Xcode 9.1 image to make room for two new build images - Xcode 11 and Xcode 10.3.

This change update the project to build on Xcode 10.2.1, the latest stable version.