### PR TITLE
Adds resources directory to deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -26,7 +26,7 @@
   rewrite-cljs  {:mvn/version "0.4.3"  :exclusions [org.clojure/tools.reader]}
   rewrite-clj {:mvn/version  "0.5.2" :exclusions [org.clojure/tools.reader]}}
 
- :paths ["src/common" "src/jvm"]
+ :paths ["src/common" "src/jvm" "resources"]
 
  :aliases
  {:test {:extra-paths ["test"]


### PR DESCRIPTION
When launching closh via the clojure cli, I noticed shell completions were not working. It turned out I wasn't able to load the completions scripts located in the resources directory. Adding resources to the classpath fixes the issue for me.