### PR TITLE
Add support `cd -` got to prev directory

### DIFF
--- a/src/common/closh/zero/builtin.cljc
+++ b/src/common/closh/zero/builtin.cljc
@@ -55,6 +55,6 @@
     (setenv "OLDPWD" (process/cwd))
     (process/chdir (str dir)) ; Extra (str ..) to handle case when directory name is a number
     (setenv "PWD" (process/cwd))
-    (when go-back?
-      (core/shx "pwd" [] {:redir [[:set 0 :stdin] [:set 2 :stderr] [:set 1 :stdout]]}))
-    env/success))
+    (if go-back?
+      (process/cwd)
+      env/success)))

--- a/test/closh/core_test.cljc
+++ b/test/closh/core_test.cljc
@@ -409,6 +409,8 @@
   (is (= (getenv "ONE") (:stdout (closh "getenv \"ONE\"")))))
 
 (deftest test-builtin-cd
+  (is (= (str/trim (:stdout (closh "pwd")))
+         (str/trim (:stdout (closh "mkdir -p out && cd out && cd - && pwd")))))
 
   (is (str/ends-with? (let [result (str/trim (:stdout (closh "mkdir -p \"out/1\" && cd out && cd 1 && pwd")))]
                         (closh "cd ../..")

--- a/test/closh/core_test.cljc
+++ b/test/closh/core_test.cljc
@@ -410,7 +410,7 @@
 
 (deftest test-builtin-cd
   (is (= (str/trim (:stdout (closh "pwd")))
-         (str/trim (:stdout (closh "mkdir -p out && cd out && cd - && pwd")))))
+         (str/trim (:stdout (closh "mkdir -p out && cd out && cd -")))))
 
   (is (str/ends-with? (let [result (str/trim (:stdout (closh "mkdir -p \"out/1\" && cd out && cd 1 && pwd")))]
                         (closh "cd ../..")


### PR DESCRIPTION
closes #166 

This PR add support for `cd -`.

Implementation based on https://pubs.opengroup.org/onlinepubs/9699919799/utilities/cd.html.

In case if `$OLDPWD` is not set up  - `~` used.
`iTerm2` also uses same approach (with `~` as default), but builtin `terminal` doesn't.
(I am on mac os)

For me `iTerm2` behavior feels more natural, but maybe you have other thoughts?

Thanks.