### PR TITLE
fix broken macro example in cookbook.

### DIFF
--- a/doc/cookbook.md
+++ b/doc/cookbook.md
@@ -123,10 +123,10 @@ popd
 
 Possible solution in closh with a macro:
 ```clojure
-(defmacro with-cwd [dir & body])
+(defmacro with-cwd [dir & body]
   `(binding [closh.zero.platform.process/*cwd*
-             (atom (closh.zero.platform.process/resolve-path dir))])
-    (sh ~@body)
+             (atom (closh.zero.platform.process/resolve-path ~dir))]
+     (sh ~@body)))
 ```
 
 Then it can be used as:


### PR DESCRIPTION
The `with-cwd` example in the cookbook has the closing ) in the wrong
place and needs to unquote it's argument.