### PR TITLE
Modernize deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
       - restore_cache: # restores saved cache if checksum hasn't changed since the last run
           key: clj-dependencies-{{ checksum "deps.edn" }}
 
-      - run: sudo apt-get -y install bc
+      - run: sudo apt-get update && sudo apt-get install -y bc
 
       # run tests
       - run: CI_ENV=1 clojure -X:test:run/test
@@ -84,7 +84,7 @@ jobs:
       - restore_cache: # restores saved cache if checksum hasn't changed since the last run
           key: clj-sci-dependencies-{{ checksum "deps.edn" }}
 
-      - run: sudo apt-get -y install bc
+      - run: sudo apt-get update && sudo apt-get install -y bc
 
       # run tests
       - run: env CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -X:sci:test:run/test
@@ -107,7 +107,7 @@ jobs:
       - restore_cache: # restores saved cache if checksum hasn't changed since the last run
           key: clj-jdk11-dependencies-{{ checksum "deps.edn" }}
 
-      - run: sudo apt-get -y install bc
+      - run: sudo apt-get update && sudo apt-get install -y bc
 
       # run tests
       - run: CI_ENV=1 clojure -X:test:run/test
@@ -130,7 +130,7 @@ jobs:
       - restore_cache: # restores saved cache if checksum hasn't changed since the last run
           key: clj-jdk11-sci-dependencies-{{ checksum "deps.edn" }}
 
-      - run: sudo apt-get -y install bc
+      - run: sudo apt-get update && sudo apt-get install -y bc
 
       # run tests
       - run:  CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -X:sci:test:run/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.1.697-node
+      - image: cimg/clojure:1.11.1-openjdk-11.0-node
 
     working_directory: ~/repo
 
@@ -15,7 +15,7 @@ jobs:
       - restore_cache: # restores saved cache if checksum hasn't changed since the last run
           key: clj-dependencies-{{ checksum "deps.edn" }}
 
-      - run: clojure -Mlint
+      - run: clojure -M:lint
 
       - save_cache: # generate and store cache in the .m2 directory using a key template
           paths:
@@ -51,7 +51,7 @@ jobs:
 
   test-linux-clj-jdk8:
     docker:
-      - image: circleci/clojure:openjdk-8-tools-deps-1.10.1.697-node
+      - image: cimg/clojure:1.11.1-openjdk-8.0-node
 
     working_directory: ~/repo
 
@@ -64,7 +64,7 @@ jobs:
       - run: sudo apt-get -y install bc
 
       # run tests
-      - run: CI_ENV=1 clojure -Mtest -m cognitect.test-runner
+      - run: CI_ENV=1 clojure -X:test:run/test
 
       - save_cache: # generate and store cache in the .m2 directory using a key template
           paths:
@@ -74,7 +74,7 @@ jobs:
 
   test-linux-clj-sci-jdk8:
     docker:
-      - image: circleci/clojure:openjdk-8-tools-deps-1.10.1.697-node
+      - image: cimg/clojure:1.11.1-openjdk-8.0-node
 
     working_directory: ~/repo
 
@@ -87,7 +87,7 @@ jobs:
       - run: sudo apt-get -y install bc
 
       # run tests
-      - run: env CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -M:sci:test -m cognitect.test-runner
+      - run: env CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -X:sci:test:run/test
 
       - save_cache: # generate and store cache in the .m2 directory using a key template
           paths:
@@ -97,7 +97,7 @@ jobs:
 
   test-linux-clj-jdk11:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.1.697-node
+      - image: cimg/clojure:1.11.1-openjdk-11.0-node
 
     working_directory: ~/repo
 
@@ -110,7 +110,7 @@ jobs:
       - run: sudo apt-get -y install bc
 
       # run tests
-      - run: CI_ENV=1 clojure -Mtest -m cognitect.test-runner
+      - run: CI_ENV=1 clojure -X:test:run/test
 
       - save_cache: # generate and store cache in the .m2 directory using a key template
           paths:
@@ -120,7 +120,7 @@ jobs:
 
   test-linux-clj-sci-jdk11:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.1.697-node
+      - image: cimg/clojure:1.11.1-openjdk-11.0-node
 
     working_directory: ~/repo
 
@@ -133,7 +133,7 @@ jobs:
       - run: sudo apt-get -y install bc
 
       # run tests
-      - run:  CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -M:sci:test -m cognitect.test-runner
+      - run:  CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -X:sci:test:run/test
 
       - save_cache: # generate and store cache in the .m2 directory using a key template
           paths:
@@ -143,7 +143,7 @@ jobs:
 
   test-macos-cljs:
     macos:
-      xcode: "11.3.1"
+      xcode: "13.4.1"
 
     working_directory: /Users/distiller/project
 
@@ -169,7 +169,7 @@ jobs:
 
   test-macos-clj:
     macos:
-      xcode: "11.3.1"
+      xcode: "13.4.1"
 
     working_directory: /Users/distiller/project
 
@@ -184,7 +184,7 @@ jobs:
       - run: brew install clojure bc
 
       # run tests
-      - run: CI_ENV=1 clojure -Mtest -m cognitect.test-runner
+      - run: CI_ENV=1 clojure -X:test:run/test
 
       - save_cache:
           paths:
@@ -194,7 +194,7 @@ jobs:
 
   test-macos-clj-sci:
     macos:
-      xcode: "11.3.1"
+      xcode: "13.4.1"
 
     working_directory: /Users/distiller/project
 
@@ -209,7 +209,7 @@ jobs:
       - run: brew install clojure bc
 
       # run tests
-      - run: CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -M:sci:test -m cognitect.test-runner
+      - run: CI_ENV=1 __CLOSH_USE_SCI_EVAL__=1 clojure -X:sci:test:run/test
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,11 +222,11 @@ workflows:
   test:
     jobs:
       - lint
-      - test-linux-cljs
+#      - test-linux-cljs
       - test-linux-clj-jdk8
       - test-linux-clj-jdk11
       - test-linux-clj-sci-jdk8
       - test-linux-clj-sci-jdk11
-      - test-macos-cljs
+#      - test-macos-cljs
       - test-macos-clj
       - test-macos-clj-sci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 - Upgrade org.clojure/java.jdbc to 0.7.12
 - Upgrade org.clojure/data.json to 2.4.0, because it's a lot faster
 - Upgrade cljfmt to 0.9.0
+- Upgrade Clojure to 1.11.1
+- Upgrade org.clojure/tools.cli to 1.0.214
+- Upgrade org.clojure/tools.reader to 1.3.6
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Upgrade org.clojure/tools.reader to 1.3.6
 - Upgrade SCI to 0.5.36, addressing https://github.com/dundalek/closh/issues/184
 - Upgrade Cognitect test runner to v0.5.1 git tag
+- Upgrade kaocha to 1.71.1119
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Upgrade Clojure to 1.11.1
 - Upgrade org.clojure/tools.cli to 1.0.214
 - Upgrade org.clojure/tools.reader to 1.3.6
+- Upgrade SCI to 0.5.36, addressing https://github.com/dundalek/closh/issues/184
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Upgrade SCI to 0.5.36, addressing https://github.com/dundalek/closh/issues/184
 - Upgrade Cognitect test runner to v0.5.1 git tag
 - Upgrade kaocha to 1.71.1119
+- Upgrade com.cemerick/pomegranate to 1.2.1
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Upgrade Cognitect test runner to v0.5.1 git tag
 - Upgrade kaocha to 1.71.1119
 - Upgrade com.cemerick/pomegranate to 1.2.1
+- Upgrade depstar to 2.1.303
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Upgrade org.clojure/java.jdbc to 0.7.12
 - Upgrade org.clojure/data.json to 2.4.0, because it's a lot faster
+- Upgrade cljfmt to 0.9.0
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,26 @@
 ## [master](https://github.com/dundalek/closh/compare/v0.5.0...master) (unreleased)
 
 ### New features
+
+- Upgrade org.xerial/sqlite-jdbc to 3.40.0.0, which provides Apple M1 compatibility
+
 ### Fixes
+
 ### Other changes
 
-## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
+- Upgrade org.clojure/java.jdbc to 0.7.12
+- Upgrade org.clojure/data.json to 2.4.0, because it's a lot faster
 
+## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 
 ### New features
 
 - JVM version: Improved history storage in (stores it in sqlite db same as the lumo version)
-- JVM version: Implemented alias expansion by [@djblue](https://github.com/djblue) ([#150](https://github.com/dundalek/closh/pull/150))
+- JVM version: Implemented alias expansion
+  by [@djblue](https://github.com/djblue) ([#150](https://github.com/dundalek/closh/pull/150))
 - JVM version: Make abbreviations work (by treating them as same as aliases for now)
-- Add support for `cd -` go to previous directory by [@kirillsalykin](https://github.com/kirillsalykin) ([#167](https://github.com/dundalek/closh/pull/167))
+- Add support for `cd -` go to previous directory
+  by [@kirillsalykin](https://github.com/kirillsalykin) ([#167](https://github.com/dundalek/closh/pull/167))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Upgrade org.clojure/tools.cli to 1.0.214
 - Upgrade org.clojure/tools.reader to 1.3.6
 - Upgrade SCI to 0.5.36, addressing https://github.com/dundalek/closh/issues/184
+- Upgrade Cognitect test runner to v0.5.1 git tag
 
 ## [0.5.0](https://github.com/dundalek/closh/compare/v0.4.1...v0.5.0) (2020-06-01)
 

--- a/README.md
+++ b/README.md
@@ -204,13 +204,21 @@ clojure -m closh.zero.frontend.rebel
 ```
 
 Run tests once
+
 ```
 npm run test
 ```
 
 Re-run tests on change
+
 ```
 npm run test-auto
+```
+
+Run tests via [Cognitect test runner](https://github.com/cognitect-labs/test-runner)
+
+```shell
+clojure -X:test:run/test
 ```
 
 ### Manual Java builds

--- a/README.md
+++ b/README.md
@@ -221,6 +221,12 @@ Run tests via [Cognitect test runner](https://github.com/cognitect-labs/test-run
 clojure -X:test:run/test
 ```
 
+Run tests via [Kaocha](https://github.com/lambdaisland/kaocha)
+
+```shell
+clojure -X:kaocha:run/kaocha
+```
+
 ### Manual Java builds
 
 Run `npm run pkg-java`. The resulting binary will be in `target/closh-zero.jar`.

--- a/deps.edn
+++ b/deps.edn
@@ -49,7 +49,12 @@
    :exec-fn   cognitect.test-runner.api/test}
 
   :depstar
-  {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
+  {:exec-fn hf.depstar/uberjar
+   :exec-args {:aot true}
+   :replace-deps
+   {com.github.seancorfield/depstar
+    {:mvn/version "2.1.303"
+     :changelog   "https://github.com/seancorfield/depstar/blob/develop/CHANGELOG.md"}}}
 
   :sci
   {:extra-paths ["src/closh-sci" "classes"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,14 @@
 {:deps
- {org.clojure/clojure        {:mvn/version "1.10.2-alpha2"}
-  org.clojure/tools.reader   {:mvn/version "1.3.2"}
+ {org.clojure/clojure        {:mvn/version "1.11.1"}
+  org.clojure/tools.reader   {:mvn/version "1.3.6"}
   org.clojure/data.json      {:mvn/version "2.4.0"}
   com.cemerick/pomegranate   {:mvn/version "1.1.0"}
-  org.clojure/tools.cli      {:mvn/version "0.4.1"}
+  org.clojure/tools.cli      {:mvn/version "1.0.214"}
   org.clojure/java.jdbc      {:mvn/version "0.7.12"}
   org.xerial/sqlite-jdbc     {:mvn/version "3.40.0.0"}
   squarepeg/squarepeg        {:mvn/version "0.6.1"}
   com.bhauman/rebel-readline {:mvn/version "0.1.4"
-                              :exclusions [rewrite-cljs/rewrite-cljs]}}
+                              :exclusions  [rewrite-cljs/rewrite-cljs]}}
 
  :paths ["src/common" "src/jvm" "resources"]
 

--- a/deps.edn
+++ b/deps.edn
@@ -21,7 +21,7 @@
              :exec-fn   cognitect.test-runner.api/test
              :homepage  "https://github.com/cognitect-labs/test-runner"}
 
-  :depstar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
+  :depstar  {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
 
   :sci      {:extra-paths ["src/closh-sci" "classes"]
              :extra-deps  {fipp/fipp        {:mvn/version "0.6.26"}
@@ -39,5 +39,11 @@
   :lint/fix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
              :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "fix"]}
 
-  :kaocha {:extra-paths ["test"]
-           :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-409"}}}}}
+  :kaocha   {:extra-paths ["test"]
+             :extra-deps  {lambdaisland/kaocha
+                           {:mvn/version "1.71.1119"
+                            :homepage    "https://github.com/lambdaisland/kaocha"}}}
+
+  :run/kaocha
+  {:exec-fn   kaocha.runner/exec-fn
+   :exec-args {}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -15,41 +15,60 @@
   {:mvn/version "1.2.1"
    :changelog   "https://github.com/clj-commons/pomegranate/blob/master/CHANGES.md"}
 
-  org.clojure/tools.cli      {:mvn/version "1.0.214"}
-  org.clojure/java.jdbc      {:mvn/version "0.7.12"}
-  org.xerial/sqlite-jdbc     {:mvn/version "3.40.0.0"}
-  squarepeg/squarepeg        {:mvn/version "0.6.1"}
-  com.bhauman/rebel-readline {:mvn/version "0.1.4"
-                              :exclusions  [rewrite-cljs/rewrite-cljs]}}
+  org.clojure/tools.cli
+  {:mvn/version "1.0.214"
+   :changelog   "https://github.com/clojure/tools.cli/blob/master/CHANGELOG.md"}
+
+  org.clojure/java.jdbc
+  {:mvn/version "0.7.12"
+   :changelog   "https://github.com/clojure/java.jdbc/blob/master/CHANGES.md"}
+
+  org.xerial/sqlite-jdbc
+  {:mvn/version "3.40.0.0"
+   :changelog   "https://github.com/xerial/sqlite-jdbc/releases"}
+
+  squarepeg/squarepeg
+  {:mvn/version "0.6.1"
+   :changelog   "https://github.com/ericnormand/squarepeg/tags"}
+
+  com.bhauman/rebel-readline
+  {:mvn/version "0.1.4"
+   :exclusions  [rewrite-cljs/rewrite-cljs]}}
 
  :paths ["src/common" "src/jvm" "resources"]
 
  :aliases
- {:test     {:extra-paths ["test"]
-             :extra-deps  {io.github.cognitect-labs/test-runner
-                           {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}
+ {:test
+  {:extra-paths ["test"]
+   :extra-deps  {io.github.cognitect-labs/test-runner
+                 {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :changelog   "https://github.com/cognitect-labs/test-runner/blob/master/changes.md"}
 
-  :run/test {:main-opts ["-m" "cognitect.test-runner"]
-             :exec-fn   cognitect.test-runner.api/test
-             :homepage  "https://github.com/cognitect-labs/test-runner"}
+  :run/test
+  {:main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn   cognitect.test-runner.api/test}
 
-  :depstar  {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
+  :depstar
+  {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
 
-  :sci      {:extra-paths ["src/closh-sci" "classes"]
-             :extra-deps  {fipp/fipp        {:mvn/version "0.6.26"}
-                           org.babashka/sci {:mvn/version "0.5.36"}
-                           borkdude/edamame {:mvn/version "1.0.16"}
-                           com.bhauman/rebel-readline
-                           {:git/url    "https://github.com/dundalek/rebel-readline.git"
-                            :sha        "123be27a75de902233356e11ac66ac53cc5edc08"
-                            :deps/root  "rebel-readline"
-                            :exclusions [rewrite-cljs/rewrite-cljs]}}}
+  :sci
+  {:extra-paths ["src/closh-sci" "classes"]
+   :extra-deps  {fipp/fipp        {:mvn/version "0.6.26"}
+                 org.babashka/sci {:mvn/version "0.5.36"}
+                 borkdude/edamame {:mvn/version "1.0.16"}
+                 com.bhauman/rebel-readline
+                 {:git/url    "https://github.com/dundalek/rebel-readline.git"
+                  :sha        "123be27a75de902233356e11ac66ac53cc5edc08"
+                  :deps/root  "rebel-readline"
+                  :exclusions [rewrite-cljs/rewrite-cljs]}}}
 
-  :lint     {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
-             :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "check"]}
+  :lint
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
+   :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "check"]}
 
-  :lint/fix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
-             :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "fix"]}
+  :lint/fix
+  {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
+   :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "fix"]}
 
   :kaocha
   {:extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -30,11 +30,11 @@
                       :deps/root "rebel-readline"
                       :exclusions [rewrite-cljs/rewrite-cljs]}}}
 
-  :lint {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
-         :main-opts ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "check"]}
+  :lint     {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
+             :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "check"]}
 
-  :lint/fix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.7.0"}}
-             :main-opts ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "fix"]}
+  :lint/fix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
+             :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "fix"]}
 
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-409"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -20,15 +20,15 @@
 
   :depstar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
 
-  :sci {:extra-paths ["src/closh-sci" "classes"]
-        :extra-deps {fipp/fipp {:mvn/version "0.6.22"}
-                     borkdude/sci {:mvn/version "0.1.0"}
-                     borkdude/edamame {:mvn/version "0.0.10"}
-                     com.bhauman/rebel-readline
-                     {:git/url "https://github.com/dundalek/rebel-readline.git"
-                      :sha "123be27a75de902233356e11ac66ac53cc5edc08"
-                      :deps/root "rebel-readline"
-                      :exclusions [rewrite-cljs/rewrite-cljs]}}}
+  :sci      {:extra-paths ["src/closh-sci" "classes"]
+             :extra-deps  {fipp/fipp        {:mvn/version "0.6.26"}
+                           org.babashka/sci {:mvn/version "0.5.36"}
+                           borkdude/edamame {:mvn/version "1.0.16"}
+                           com.bhauman/rebel-readline
+                           {:git/url    "https://github.com/dundalek/rebel-readline.git"
+                            :sha        "123be27a75de902233356e11ac66ac53cc5edc08"
+                            :deps/root  "rebel-readline"
+                            :exclusions [rewrite-cljs/rewrite-cljs]}}}
 
   :lint     {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
              :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "check"]}

--- a/deps.edn
+++ b/deps.edn
@@ -1,12 +1,12 @@
 {:deps
- {org.clojure/clojure {:mvn/version "1.10.2-alpha2"}
-  org.clojure/tools.reader {:mvn/version "1.3.2"}
-  org.clojure/data.json {:mvn/version "0.2.6"}
-  com.cemerick/pomegranate {:mvn/version "1.1.0"}
-  org.clojure/tools.cli {:mvn/version "0.4.1"}
-  org.clojure/java.jdbc {:mvn/version "0.7.9"}
-  org.xerial/sqlite-jdbc {:mvn/version "3.27.2.1"}
-  squarepeg/squarepeg {:mvn/version "0.6.1"}
+ {org.clojure/clojure        {:mvn/version "1.10.2-alpha2"}
+  org.clojure/tools.reader   {:mvn/version "1.3.2"}
+  org.clojure/data.json      {:mvn/version "2.4.0"}
+  com.cemerick/pomegranate   {:mvn/version "1.1.0"}
+  org.clojure/tools.cli      {:mvn/version "0.4.1"}
+  org.clojure/java.jdbc      {:mvn/version "0.7.12"}
+  org.xerial/sqlite-jdbc     {:mvn/version "3.40.0.0"}
+  squarepeg/squarepeg        {:mvn/version "0.6.1"}
   com.bhauman/rebel-readline {:mvn/version "0.1.4"
                               :exclusions [rewrite-cljs/rewrite-cljs]}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,20 @@
 {:deps
- {org.clojure/clojure        {:mvn/version "1.11.1"}
-  org.clojure/tools.reader   {:mvn/version "1.3.6"}
-  org.clojure/data.json      {:mvn/version "2.4.0"}
-  com.cemerick/pomegranate   {:mvn/version "1.1.0"}
+ {org.clojure/clojure
+  {:mvn/version "1.11.1"
+   :changelog   "https://github.com/clojure/clojure/blob/master/changes.md"}
+
+  org.clojure/tools.reader
+  {:mvn/version "1.3.6"
+   :changelog   "https://github.com/clojure/tools.reader/blob/master/CHANGELOG.md"}
+
+  org.clojure/data.json
+  {:mvn/version "2.4.0"
+   :changelog   "https://github.com/clojure/data.json#change-log"}
+
+  clj-commons/pomegranate
+  {:mvn/version "1.2.1"
+   :changelog   "https://github.com/clj-commons/pomegranate/blob/master/CHANGES.md"}
+
   org.clojure/tools.cli      {:mvn/version "1.0.214"}
   org.clojure/java.jdbc      {:mvn/version "0.7.12"}
   org.xerial/sqlite-jdbc     {:mvn/version "3.40.0.0"}
@@ -39,10 +51,11 @@
   :lint/fix {:extra-deps {cljfmt/cljfmt {:mvn/version "0.9.0"}}
              :main-opts  ["-m" "cljfmt.main" "--file-pattern" "(?<!clojure_main_sci)\\.clj[csx]?$" "fix"]}
 
-  :kaocha   {:extra-paths ["test"]
-             :extra-deps  {lambdaisland/kaocha
-                           {:mvn/version "1.71.1119"
-                            :homepage    "https://github.com/lambdaisland/kaocha"}}}
+  :kaocha
+  {:extra-paths ["test"]
+   :extra-deps  {lambdaisland/kaocha
+                 {:mvn/version "1.71.1119"
+                  :changelog   "https://github.com/lambdaisland/kaocha/blob/main/CHANGELOG.md"}}}
 
   :run/kaocha
   {:exec-fn   kaocha.runner/exec-fn

--- a/deps.edn
+++ b/deps.edn
@@ -13,10 +13,13 @@
  :paths ["src/common" "src/jvm" "resources"]
 
  :aliases
- {:test {:extra-paths ["test"]
-         :extra-deps {com.cognitect/test-runner
-                      {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                       :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}}
+ {:test     {:extra-paths ["test"]
+             :extra-deps  {io.github.cognitect-labs/test-runner
+                           {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}
+
+  :run/test {:main-opts ["-m" "cognitect.test-runner"]
+             :exec-fn   cognitect.test-runner.api/test
+             :homepage  "https://github.com/cognitect-labs/test-runner"}
 
   :depstar {:extra-deps {seancorfield/depstar {:mvn/version "1.1.117"}}}
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "docker-start": "npm run docker-build && docker run --rm -it closh",
     "pkg-lumo": "pkg-lumo -c src/common:src/lumo -m closh.main",
     "pkg-java": "npm run compile-uberjar && scripts/wrap-jar.sh target/closh-zero.jar",
-    "compile-uberjar": "clojure -M:depstar -m hf.depstar.uberjar --compile -m closh.zero.frontend.rebel target/closh-zero.jar --verbose",
+    "compile-uberjar": "clojure -X:depstar :main-class closh.zero.frontend.rebel :jar target/closh-zero.jar :verbose true",
     "lint": "clojure -M:lint",
     "lint-fix": "clojure -M:lint:lint/fix",
     "lint-kondo": "clj-kondo --lint src:test",

--- a/scripts/compile-sci-uberjar
+++ b/scripts/compile-sci-uberjar
@@ -10,4 +10,4 @@ rm -rf classes
 mkdir classes
 clojure -Msci -e "(compile 'rebel-readline.line-reader-class)"
 clojure -Asci -Spom
-clojure -M:depstar:sci -m hf.depstar.uberjar --compile -m closh.zero.frontend.sci-rebel "$jar" # --verbose
+clojure -X:depstar :aliases '[:sci]' :main-class closh.zero.frontend.sci-rebel :jar "$jar" :verbose true

--- a/src/jvm/closh/zero/utils/clojure_main.clj
+++ b/src/jvm/closh/zero/utils/clojure_main.clj
@@ -18,7 +18,6 @@
                          LineNumberingPushbackReader RT LispReader$ReaderException)))
   ;;(:use [clojure.repl :only (demunge root-cause stack-element-str)])
 
-
 (declare main)
 
 ;;;;;;;;;;;;;;;;;;; redundantly copied from clojure.repl to avoid dep ;;;;;;;;;;;;;;
@@ -70,7 +69,6 @@
            (str (.getClassName el) "." (.getMethodName el)))
          " (" (.getFileName el) ":" (.getLineNumber el) ")")))
 ;;;;;;;;;;;;;;;;;;; end of redundantly copied from clojure.repl to avoid dep ;;;;;;;;;;;;;;
-
 
 (defmacro with-bindings
   "Executes body in the context of thread-local bindings for several vars


### PR DESCRIPTION
Keep the Clojure version usable on modern hardware (Apply Silicon aka M1 / M2 Macs).

Since, the CLJS variant relies on the unmaintained `lumo` project, this PR doesn't try to address dependency upgrades for that.